### PR TITLE
Remove max age session cookie

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,6 +16,9 @@ homepage: "https://www.aimwel.com"
 documentation: See "README.md" in project root
 versions:
   # Latest version
+  - sha: __GIT_SHA__
+    changeNotes: Changed session cookie to browser session-based (expires on browser close instead of 30-minute sliding window)
+  # Older versions
   - sha: fc2a5089e03a41d94b29a48305fb4f1e8eb1cbae
     changeNotes: |2
       1. Renamed pixel version parameter (v → px_v) with automatic version injection via GitHub Actions
@@ -25,7 +28,6 @@ versions:
       5. Refactored pixel code for clarity and simplicity
       6. Refactored and expanded test coverage
       7. Added CI check to ensure pixel.js matches template.tpl
-  # Older versions
   - sha: 658b70185420c533ce0e9e3da5112975e195a158
     changeNotes: Added registration event type
   - sha: a437825d563b120bde8ec7c8d068ea8c4de4c265

--- a/pixel.js
+++ b/pixel.js
@@ -48,7 +48,6 @@ data.platformParameters.forEach(function(p) {
 const sessionCookieOpts = {
     domain: 'auto',
     path: '/',
-    'max-age': 1800,
     samesite: 'Lax',
     secure: true
 };

--- a/template.tpl
+++ b/template.tpl
@@ -226,7 +226,7 @@ const getContainerVersion = require('getContainerVersion');
 
 
 // Constants
-const PIXEL_VERSION = 'fc2a508';
+const PIXEL_VERSION = '__GIT_SHA__';
 const SESSION_COOKIE = '_aimwel_session';
 const PARAMS_COOKIE = '_aimwel_params';
 const GA_COOKIE = '_ga';
@@ -262,7 +262,6 @@ data.platformParameters.forEach(function(p) {
 const sessionCookieOpts = {
     domain: 'auto',
     path: '/',
-    'max-age': 1800,
     samesite: 'Lax',
     secure: true
 };
@@ -1342,7 +1341,6 @@ setup: |
   const cookieOptionsSession = {
       domain: 'auto',
       path: '/',
-      'max-age': 1800,
       samesite: 'Lax',
       secure: true
   };
@@ -1460,7 +1458,7 @@ setup: |
           '?timestamp=1000' +
           '&session_id=' + sessionId +
           '&event_type=' + eventType +
-          '&px_v=fc2a508' +
+          '&px_v=__GIT_SHA__' +
           '&cv_id=GTM-TEST123' +
           '&cv_v=1' +
           '&cv_env=' +

--- a/tests/_setup.js
+++ b/tests/_setup.js
@@ -11,7 +11,6 @@ const GA_COOKIE = '_ga';
 const cookieOptionsSession = {
     domain: 'auto',
     path: '/',
-    'max-age': 1800,
     samesite: 'Lax',
     secure: true
 };


### PR DESCRIPTION
This pull request updates the session cookie behavior to expire when the browser is closed, rather than after a 30-minute sliding window. It also introduces dynamic versioning for the pixel code by injecting the current git SHA into relevant files and metadata. These changes improve session security and ensure accurate version tracking.

**Session Cookie Behavior Update**
* Removed the `'max-age': 1800` option from session cookie settings in `pixel.js`, `template.tpl`, and `tests/_setup.js`, making the session cookie expire on browser close instead of after 30 minutes. [[1]](diffhunk://#diff-57b743d11d7cdb3d271b8005cd049abab184eb5e7d651023101c459612af2d39L51) [[2]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292L265) [[3]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292L1345) [[4]](diffhunk://#diff-1cb6951dd0d7fe96522c0eb4625de7c962d45912578612852fc0ffbd7555cb7fL14)

**Dynamic Versioning**
* Updated `PIXEL_VERSION` and all references to pixel version in `template.tpl` to use `__GIT_SHA__` instead of a hardcoded value, ensuring the deployed version matches the current git commit. [[1]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292L229-R229) [[2]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292L1463-R1461)
* Updated `metadata.yaml` to track the new version with `sha: __GIT_SHA__` and corresponding change notes.
* Minor cleanup in `metadata.yaml` version history for clarity.