### PR TITLE
GitHub actions improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,31 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref }}
 
-      - name: Inject version
-        run: |
-          sed -i "s/__GIT_SHA__/${GITHUB_SHA::7}/g" template.tpl
-          sed -i "s/__GIT_SHA__/${GITHUB_SHA}/g" metadata.yaml
-
-      - name: Commit and push
+      - name: Inject version (two-pass)
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+
+          # First pass: Replace __GIT_SHA__ with the triggering commit SHA
+          TRIGGER_SHA_SHORT=${GITHUB_SHA::7}
+          TRIGGER_SHA_FULL=${GITHUB_SHA}
+
+          sed -i "s/__GIT_SHA__/${TRIGGER_SHA_SHORT}/g" template.tpl
+          sed -i "s/__GIT_SHA__/${TRIGGER_SHA_FULL}/g" metadata.yaml
+
           git add template.tpl metadata.yaml
-          git commit -m "Inject version ${GITHUB_SHA::7} [ci skip]"
+          git commit -m "Inject version ${TRIGGER_SHA_SHORT} [ci skip]"
+
+          # Get the SHA of the commit we just created
+          FIRST_COMMIT_SHA=$(git rev-parse HEAD)
+          FIRST_COMMIT_SHA_SHORT=${FIRST_COMMIT_SHA::7}
+
+          # Second pass: Replace the trigger SHA with the first commit SHA
+          # This makes the latest commit point to a commit with valid metadata
+          sed -i "s/${TRIGGER_SHA_SHORT}/${FIRST_COMMIT_SHA_SHORT}/g" template.tpl
+          sed -i "s/${TRIGGER_SHA_FULL}/${FIRST_COMMIT_SHA}/g" metadata.yaml
+
+          git add template.tpl metadata.yaml
+          git commit -m "Inject version ${FIRST_COMMIT_SHA_SHORT} [ci skip]"
+
           git push

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,9 +16,11 @@ homepage: "https://www.aimwel.com"
 documentation: See "README.md" in project root
 versions:
   # Latest version
+  - sha: __GIT_SHA__
+    changeNotes: Updated CI workflow for two-pass SHA injection to ensure referenced commits have valid metadata
+  # Older versions
   - sha: d20d8c00d1633eefba35fa22f916bf4c214da811
     changeNotes: Changed session cookie to browser session-based (expires on browser close instead of 30-minute sliding window)
-  # Older versions
   - sha: fc2a5089e03a41d94b29a48305fb4f1e8eb1cbae
     changeNotes: |2
       1. Renamed pixel version parameter (v → px_v) with automatic version injection via GitHub Actions

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,4 @@
-﻿___INFO___
+___INFO___
 
 {
   "type": "TAG",
@@ -226,7 +226,7 @@ const getContainerVersion = require('getContainerVersion');
 
 
 // Constants
-const PIXEL_VERSION = 'd20d8c0';
+const PIXEL_VERSION = '__GIT_SHA__';
 const SESSION_COOKIE = '_aimwel_session';
 const PARAMS_COOKIE = '_aimwel_params';
 const GA_COOKIE = '_ga';


### PR DESCRIPTION
This pull request updates the CI workflow to improve how version information is injected into build artifacts, ensuring that the metadata in `template.tpl` and `metadata.yaml` always references a valid commit. The main change is a switch to a two-pass SHA injection process, which resolves issues with referencing uncommitted SHAs. Additionally, the versioning mechanism in the codebase is updated to use a placeholder that is dynamically replaced during the CI process.

**CI/CD Workflow Improvements:**

* The GitHub Actions workflow in `.github/workflows/build.yml` now performs a two-pass SHA injection. In the first pass, it replaces `__GIT_SHA__` with the triggering commit SHA, commits the change, then in the second pass updates the placeholder with the actual commit SHA of the new commit, ensuring all references point to a committed revision.

**Versioning and Metadata Updates:**

* The `PIXEL_VERSION` constant in `template.tpl` now uses the `__GIT_SHA__` placeholder, which is replaced during the CI workflow, making version tracking more robust and automated.
* The `metadata.yaml` file is updated to include a new version entry with the `__GIT_SHA__` placeholder and notes about the updated CI workflow, improving transparency and traceability of changes.

**Minor Formatting Fixes:**

* Fixed a minor formatting issue at the top of `template.tpl` (removal of BOM character).